### PR TITLE
add action build nightly version

### DIFF
--- a/.github/workflows/build_windows_nightly.yml
+++ b/.github/workflows/build_windows_nightly.yml
@@ -1,0 +1,77 @@
+name: MirrorX Nightly Build
+
+on:
+  schedule:
+    # schedule build every night
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  TAG_NAME: "nightly"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.5.0
+      - name: Setup node.js
+        uses: actions/setup-node@v3.5.1
+      - name: enable yarn v3
+        run: corepack enable
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Download Pre Built Media Libraries Zip
+        uses: robinraju/release-downloader@v1.6
+        with:
+          repository: "MirrorX-Desktop/media_libraries_auto_build"
+          tag: "latest"
+          fileName: "artifacts_windows_x64.zip"
+      - name: Unzip Pre Built Media Libraries
+        run: |
+          7z x artifacts_windows_x64.zip -oartifacts_windows_x64
+      - name: ls
+        run: |
+          Get-ChildItem
+      - name: Set Pre Built Media Libraries Path
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "MIRRORX_MEDIA_LIBS_PATH=${{github.workspace}}\\artifacts_windows_x64"
+      - name: Setup tauri-cli
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: tauri-cli
+          version: "1.2.2"
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: build
+        run: cargo tauri build
+      - name: Zip
+        run: |
+          7z a MirrorX_x64.zip ${{github.workspace}}\\target\\release\\MirrorX.exe
+      - name: Publish Release
+        uses: ncipollo/release-action@v1
+        with:
+          prerelease: true
+          artifacts: "MirrorX_x64.zip,D:\\a\\MirrorX\\MirrorX\\target\\release\\bundle\\msi\\*.msi"
+          tag: ${{ env.TAG_NAME }}
+          allowUpdates: true


### PR DESCRIPTION
add action build nightly version.  
每晚00点构建.  
与build_win不同的是**会发布msi**    

以及将 tauri-cli 的 version 升至 "1.2.2"